### PR TITLE
camelCase JSON property naming instead of snake-case

### DIFF
--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -19,13 +19,11 @@ This implies in turn that object names should be singular.
 
 
 [#118]
-== {MUST} property names must be ASCII snake_case (and never camelCase): `^[a-z_][a-z_0-9]*$`
+== {MUST} property names must be ASCII strict lower camelCase: `[a-z]+((\d)|([A-Z0-9][a-z0-9]+))*([A-Z])?`
 
 Property names are restricted to ASCII strings. The first
-character must be a letter, or an underscore, and subsequent
-characters can be a letter, an underscore, or a number.
-
-(It is recommended to use `_` at the start of property names only for keywords like `_links`.)
+character must be a letter and subsequent
+characters can be a letter or a number.
 
 Rationale: No established industry standard exists, but many popular Internet
 companies prefer snake_case: e.g. GitHub, Stack Exchange, Twitter.


### PR DESCRIPTION
✨ Summary of this change
Changed snake-case based naming proposal to camelCase 

📝 Links to relevant issues/docs
n/a

🧑‍💻 Details
💥 Reasons for headache (breaking changes, workarounds, ugly compromises)

🤔 Checklist before submitting
 Has been discussed internally in the APIX team