### PR TITLE
Added 'localized-string' format to OAS3 formats.

### DIFF
--- a/chapters/data-formats.adoc
+++ b/chapters/data-formats.adoc
@@ -104,6 +104,7 @@ You *must* use these formats, whenever applicable:
 | `string` | <<144, `uuid`>> | {RFC-4122}[RFC 4122] | `"e2ab873e-b295-11e9-9c02-..."`
 | `string` | `json-pointer` | {RFC-6901}[RFC 6901] | `"/items/0/id"`
 | `string` | `regex` | regular expressions as defined in {ECMA-262}[ECMA 262] | `"^[a-z0-9]+$"`
+| `string` | `localized-string` | A string which is localized in the requested language | `"Fällige Wartungen"`
 |=====================================================================
 
 *Remark:* Please note that this list of standard data formats is not exhaustive 


### PR DESCRIPTION
## ✨  **Summary of this change**
Documentation of localized strings if localization is provided by an API endpoint. 
## 📝 Links to relevant issues/docs
https://confluence01.com.stihlgroup.net/display/DIPO/2021-08-19+APIX
## 🧑‍💻 **Details**
Localized strings can be documented using description property in OAS3 or using an format definition.
Pro format:
* Clear documentation in any kind of swagger ui's

Con format:
* Format should be somthing which can be checked by a syntax checker. which is not the case for localized strings.

Pro description:
* null

Con description:
*The description might be needed for additional information about the strings content.

## 💥 **Reasons for headache** (breaking changes, workarounds, ugly compromises)
* Format is not auditable for localized strings

## 🤔 **Checklist before submitting**
 Has been discussed internally in the APIX meeting.
